### PR TITLE
Allow default but not forced recurring

### DIFF
--- a/CRM/Contributionrecur/Form/ContributionRecurSettings.php
+++ b/CRM/Contributionrecur/Form/ContributionRecurSettings.php
@@ -32,6 +32,11 @@ class CRM_Contributionrecur_Form_ContributionRecurSettings extends CRM_Core_Form
     );
     $this->add(
       'checkbox', // field type
+      'default_recur', // field name
+      ts('Default the "recurring contribution" checkbox to "true" but allow users to uncheck it.')
+    );
+    $this->add(
+      'checkbox', // field type
       'nice_recur', // field name
       ts('Add a nice js-based recurring/non-recurring switcher.')
     );

--- a/CRM/Contributionrecur/Form/PageSettings.php
+++ b/CRM/Contributionrecur/Form/PageSettings.php
@@ -55,7 +55,12 @@ class CRM_Contributionrecur_Form_PageSettings extends CRM_Contribute_Form_Contri
       ts('Add a nice js-based recurring/non-recurring switcher.'),
       $options
     );
-
+    $this->add(
+      'select', // field type
+      'default_recur', // field name
+      ts('Default the recurring checkbox to checked, but allow users to uncheck it.'),
+      $options
+    );
     /* $this->addButtons(array(
       array(
         'type' => 'submit',
@@ -81,6 +86,7 @@ class CRM_Contributionrecur_Form_PageSettings extends CRM_Contribute_Form_Contri
     $settings = array(
       'force_recur' => $values['force_recur'], 
       'nice_recur' => $values['nice_recur'], 
+      'default_recur' => $values['default_recur'],
     );
     // Source
     $page_id = $this->_id;

--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ As an option, for (all) contribution pages that offer a recurring option - make 
 
 If you want to modify that behaviour per contribution page (e.g. for a specific contribution page enable that functionality or disable it from a default on), you can do that on the extension-provided "Recurring" tab per contribution page.
 
+## Default the "recurring payment" checkbox to checked
+
+As an option, for (all) contribution pages that offer a recurring option - default the checkbox to checked, but allow contributors to uncheck the box.
+
+If you want to modify that behaviour per contribution page (e.g. for a specific contribution page enable that functionality or disable it from a default on), you can do that on the extension-provided "Recurring" tab per contribution page.
+
 ## Provide a js-based recurring/non-recurring switcher ##
 
 A simple header block that enables/disables the recurring checkbox. Both a global configuration and a per-contribution-page override option. The contribution page needs to have recurring enabled, and you need to use a price set to match the hard-coded classes in the js here: https://github.com/adixon/ca.civicrm.contributionrecur/blob/master/js/donation.js

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you want to modify that behaviour per contribution page (e.g. for a specific 
 
 ## Default the "recurring payment" checkbox to checked
 
-As an option, for (all) contribution pages that offer a recurring option - default the checkbox to checked, but allow contributors to uncheck the box.
+As an option, for (all) contribution pages that offer a recurring option - default the checkbox to checked, but allow contributors to uncheck the box.  If "default to recurring" and "force recurring" are both selected, "default to recurring" will have no effect.
 
 If you want to modify that behaviour per contribution page (e.g. for a specific contribution page enable that functionality or disable it from a default on), you can do that on the extension-provided "Recurring" tab per contribution page.
 

--- a/contributionrecur.php
+++ b/contributionrecur.php
@@ -453,7 +453,7 @@ function contributionrecur_CRM_Contribute_Form_Contribution_Main(&$form) {
   $settings = CRM_Core_BAO_Setting::getItem('Recurring Contributions Extension', 'contributionrecur_settings');
   $page_id = $form->getVar('_id');
   $page_settings = CRM_Core_BAO_Setting::getItem('Recurring Contributions Extension', 'contributionrecur_settings_'.$page_id);
-  foreach(array('force_recur','nice_recur') as $setting) {
+  foreach (array('default_recur', 'force_recur', 'nice_recur') as $setting) {
     if (!empty($page_settings[$setting])) {
       $settings[$setting] = ($page_settings[$setting] > 0) ? 1 : 0;
     }
@@ -468,6 +468,9 @@ function contributionrecur_CRM_Contribute_Form_Contribution_Main(&$form) {
   elseif (!empty($settings['nice_recur'])) {
     CRM_Core_Resources::singleton()->addStyleFile('ca.civicrm.contributionrecur', 'css/donation.css');
     CRM_Core_Resources::singleton()->addScriptFile('ca.civicrm.contributionrecur', 'js/donation.js');
+    $form->setDefaults(array('is_recur' => 1)); // make recurring contrib default to true
+  }
+  if (!empty($settings['default_recur'])) {
     $form->setDefaults(array('is_recur' => 1)); // make recurring contrib default to true
   }
   // if the site administrator has resticted the recurring days


### PR DESCRIPTION
I had a client who wanted the "recurring" checkbox to default to true, but not forced to true, as do a couple folks on Stack Exchange.  Since your extension is so close in functionality, I thought it made more sense to add it as an option rather than a whole new extension or custom tweak.