### PR TITLE
Hide pricesetTotal

### DIFF
--- a/js/donation.js
+++ b/js/donation.js
@@ -14,6 +14,8 @@ CRM.$(function ($) {
     $('.crm-contribution-main-form-block').has('#intro_text').before($('#intro_text'));
   }
   $('#priceset-div').before('<div class="gift-type-select"><div id="monthly-gift"><label>Monthly Gift</label></div><div id="one-time-gift"><label>One-time Gift</label></div></div>');
+  $('#pricesetTotal').hide();
+
   if ($('#is_recur').prop('checked')) {
     setRecur();
   }


### PR DESCRIPTION
This div is showing an incorrect amount if you select a one-time option and then switch over to the recurring tab or if you select an option and then an other amount after (it just keeps adding). The actual charged amount is correct and I don't really think this calculated field is needed, so I've just hidden it. But maybe you want to fix it instead?