### PR TITLE
Add comma to fix syntax error

### DIFF
--- a/CRM/Contributionrecur/Form/PageSettings.php
+++ b/CRM/Contributionrecur/Form/PageSettings.php
@@ -59,7 +59,7 @@ class CRM_Contributionrecur_Form_PageSettings extends CRM_Contribute_Form_Contri
       'select', // field type
       'default_recur', // field name
       ts('Default the recurring checkbox to checked, but allow users to uncheck it.'),
-      $options
+      $options,
       'text',
       'name_monthly_gift',
       ts('Machine name for monthly gift amount price field.'),


### PR DESCRIPTION
Overview
----------------------------------------
An error is being triggered by a missing comma in `CRM/Contributionrecur/Form/PageSettings.php`. 

Before / Replication Steps
----------------------------------------
If a user goes to the 'Recurring' tab on a Contribution page, the contents of that tab do not load and they receive a 'network error' message in the upper right corner.

After
----------------------------------------
With this syntax fix, the user does not encounter an error when loading the  'Recurring' tab on a Contribution page.

Additional Information
----------------------------------------
There is another error at play here that is not addressed by this PR. When a user clicks **Save** on this form, the page displays a message that 'No contributions pages have been created yet'. There is a work around to go back to *Manage Contribution Pages* and edit the desired page again, but the user should not have to back track to make edits after saving.

![Selection_132](https://github.com/adixon/ca.civicrm.contributionrecur/assets/87245718/a21c2dfc-24e3-47dc-b2ec-510875667114)
