### PR TITLE
#29: Add setting to disable settings included in recurux

### DIFF
--- a/CRM/Contributionrecur/Form/ContributionRecurSettings.php
+++ b/CRM/Contributionrecur/Form/ContributionRecurSettings.php
@@ -35,27 +35,38 @@ class CRM_Contributionrecur_Form_ContributionRecurSettings extends CRM_Core_Form
       'no_receipts', // field name
       ts('Prevent all receipts for recurring contributions')
     );
+
     $this->add(
       'checkbox', // field type
-      'force_recur', // field name
-      ts('Force recurring-only option on pages that it is available')
+      'disable_for_recurux', // field name
+      ts('Disable all settings that are found in RecurUX extension')
     );
-    $this->add(
-      'checkbox', // field type
-      'default_recur', // field name
-      ts('Default the "recurring contribution" checkbox to "true" but allow users to uncheck it.')
-    );
-    $this->add(
-      'checkbox', // field type
-      'nice_recur', // field name
-      ts('Add a nice js-based recurring/non-recurring switcher')
-    );
-    $this->add(
-      'checkbox', // field type
-      'default_membership_auto_renew', // field name
-      ts('Modify default membership auto-renew to "on"')
-    );
-    // allow selection of activity type for implicit membership renewal 
+
+    $contributionrecur_settings = Civi::settings()->get('contributionrecur_settings');
+    if (empty($contributionrecur_settings['disable_for_recurux'])) {
+      $this->add(
+        'checkbox', // field type
+        'force_recur', // field name
+        ts('Force recurring-only option on pages that it is available')
+      );
+      $this->add(
+        'checkbox', // field type
+        'default_recur', // field name
+        ts('Default the "recurring contribution" checkbox to "true" but allow users to uncheck it.')
+      );
+      $this->add(
+        'checkbox', // field type
+        'nice_recur', // field name
+        ts('Add a nice js-based recurring/non-recurring switcher')
+      );
+      $this->add(
+        'checkbox', // field type
+        'default_membership_auto_renew', // field name
+        ts('Modify default membership auto-renew to "on"')
+      );
+    }
+
+    // allow selection of activity type for implicit membership renewal
     $result = civicrm_api3('OptionValue', 'get', array('sequential' => 1, 'return' => "value,label", 'option_group_id' => 'activity_type', 'rowCount' => 100, 'component_id' => array('IS NULL' => '1'), 'is_active' => 1,));
     $activity_types = array('0' => '-- none --');
     foreach($result['values'] as $activity_type) {
@@ -83,7 +94,7 @@ class CRM_Contributionrecur_Form_ContributionRecurSettings extends CRM_Core_Form
       FALSE,
       $attr
     );
-    
+
     $day_select->setMultiple(TRUE);
     $day_select->setSize(29);
     $this->addButtons(array(
@@ -108,7 +119,7 @@ class CRM_Contributionrecur_Form_ContributionRecurSettings extends CRM_Core_Form
       if (isset($values[$key])) {
         unset($values[$key]);
       }
-    } 
+    }
     CRM_Core_BAO_Setting::setItem($values, 'Recurring Contributions Extension', 'contributionrecur_settings');
     parent::postProcess();
   }

--- a/contributionrecur.php
+++ b/contributionrecur.php
@@ -402,7 +402,10 @@ function contributionrecur_CRM_Contribute_Form_Contribution_Main(&$form) {
   $page_id = $form->getVar('_id');
   $page_settings = Civi::settings()->get('contributionrecur_settings_'.$page_id);
   foreach(array('default_recur','force_recur','nice_recur','default_membership_auto_renew') as $setting) {
-    if (!empty($page_settings[$setting])) {
+    if (!empty($contributionrecur_settings['disable_for_recurux'])) {
+      $contributionrecur_settings[$setting] = 0;
+    }
+    elseif (!empty($page_settings[$setting])) {
       $contributionrecur_settings[$setting] = ($page_settings[$setting] > 0) ? 1 : 0;
     }
   }
@@ -649,6 +652,10 @@ function _contributionrecur_civicrm_getContributionTemplate($contribution) {
 function contributionrecur_civicrm_tabset($tabsetName, &$tabs, $context) {
   //check if the tabset is Contribution Page
   if ($tabsetName == 'civicrm/admin/contribute') {
+    $contributionrecur_settings = Civi::settings()->get('contributionrecur_settings');
+    if (!empty($contributionrecur_settings['disable_for_recurux'])) {
+      return;
+    }
     if (!empty($context['contribution_page_id'])) {
       $contribID = $context['contribution_page_id'];
       $url = CRM_Utils_System::url( 'civicrm/admin/contribute/recur',


### PR DESCRIPTION
Thought it was better just to add a setting, then admins can enable or disable as they see fit (e.g. to refer to while copying the values over). Enabling this setting removes the Recurring tab from the contribution pages and disables the js, etc as well as hiding the fields on the settings page (on reload).