### PR TITLE
Don't show incorrect warning about changed amount

### DIFF
--- a/CRM/Core/Payment/RecurOfflineACHEFT.php
+++ b/CRM/Core/Payment/RecurOfflineACHEFT.php
@@ -69,8 +69,6 @@ class CRM_Core_Payment_RecurOfflineACHEFT extends CRM_Core_Payment {
    *
    */
   public function changeSubscriptionAmount(&$message = '', $params = array()) {
-    $userAlert = ts('You have updated the amount of this recurring contribution.');
-    CRM_Core_Session::setStatus($userAlert, ts('Warning'), 'alert');
     return TRUE;
   }
 


### PR DESCRIPTION
I think maybe something is wrong in core that it always warns about having changed the amount even when you just edit the next scheduled date or similar and don't touch the amount. But this warning isn't really needed, because there is an alert that tells you what you've changed it to anyways. Either way, the warning as it stands is not useful because it says that you've changed the amount no matter if you have or not, so I'm sure everyone ignores it.

Before:
![image](https://github.com/user-attachments/assets/da2d5ecf-0a92-4bef-8f27-8368fb019de4)

After:
![image](https://github.com/user-attachments/assets/6ff1a6e9-7508-4db1-a452-509fc56292d3)
