### PR TITLE
Remove calls to deprecated CRM_Utils_Array::value

### DIFF
--- a/CRM/Contributionrecur/Form/ContributionRecurAdHoc.php
+++ b/CRM/Contributionrecur/Form/ContributionRecurAdHoc.php
@@ -37,7 +37,7 @@ class CRM_Contributionrecur_Form_ContributionRecurAdHoc extends CRM_Core_Form {
     }
     // create the pending contribution, and save its id
     $contributionResult = civicrm_api('contribution','create', $contribution);
-    $contribution_id = CRM_Utils_Array::value('id', $contributionResult);
+    $contribution_id = $contributionResult['id'] ?? NULL;
     return 'Created new contribution id: '.$contribution_id;
   }
 

--- a/CRM/Contributionrecur/Form/Report/Recur.php
+++ b/CRM/Contributionrecur/Form/Report/Recur.php
@@ -378,25 +378,25 @@ class CRM_Contributionrecur_Form_Report_Recur extends CRM_Report_Form {
       }
 
       // handle contribution status id
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_contribution_status_id', $row)) {
+      if ($value = $row['civicrm_contribution_recur_contribution_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_recur_contribution_status_id'] = self::$contributionStatus[$value];
       }
       // handle membership status id
-      if ($value = CRM_Utils_Array::value('civicrm_membership_status_id', $row)) {
+      if ($value = $row['civicrm_membership_status_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_membership_status_id'] = self::$membershipStatus[$value];
       }
       // handle processor id
-      if ($value = CRM_Utils_Array::value('civicrm_contribution_recur_payment_processor_id', $row)) {
+      if ($value = $row['civicrm_contribution_recur_payment_processor_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contribution_recur_payment_processor_id'] = self::$processors[$value];
       }
       // handle address country and province id => value conversion
-      if ($value = CRM_Utils_Array::value('civicrm_address_country_id', $row)) {
+      if ($value = $row['civicrm_address_country_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_address_country_id'] = CRM_Core_PseudoConstant::country($value, FALSE);
       }
-      if ($value = CRM_Utils_Array::value('civicrm_address_state_province_id', $row)) {
+      if ($value = $row['civicrm_address_state_province_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_address_state_province_id'] = CRM_Core_PseudoConstant::stateProvince($value, FALSE);
       }
-      if ($value = CRM_Utils_Array::value('civicrm_contact_prefix_id', $row)) {
+      if ($value = $row['civicrm_contact_prefix_id'] ?? NULL) {
         $rows[$rowNum]['civicrm_contact_prefix_id'] = self::$prefixes[$value];
       }
     }

--- a/CRM/Contributionrecur/MembershipImplicit.php
+++ b/CRM/Contributionrecur/MembershipImplicit.php
@@ -68,8 +68,8 @@ function contributionrecur_membershipImplicit($contact, $contributions, $options
     }
     $updated_membership = array('contact_id' => $contact_id, 'id' => $membership['id']);
     $dates = CRM_Member_BAO_MembershipType::getRenewalDatesForMembershipType($membership['id'],date('YmdHis',strtotime($start_date)),$membership['membership_type_id'],1);
-    $updated_membership['start_date'] = CRM_Utils_Array::value('start_date', $dates);
-    $updated_membership['end_date'] = CRM_Utils_Array::value('end_date', $dates);
+    $updated_membership['start_date'] = $dates['start_date'] ?? NULL;
+    $updated_membership['end_date'] = $dates['end_date'] ?? NULL;
     $updated_membership['source'] = ts('Auto-renewed membership from contribution of implicit membership type');
     $updated_membership['status_id'] = 2; // always set to current now
     civicrm_api3('Membership','create',$updated_membership);

--- a/api/v3/Job/Recurringgenerate.php
+++ b/api/v3/Job/Recurringgenerate.php
@@ -229,7 +229,7 @@ function civicrm_api3_job_recurringgenerate($params) {
       civicrm_api3_create_error($contributionResult['error_message']);
       break;
     }
-    $contribution_id = CRM_Utils_Array::value('id', $contributionResult);
+    $contribution_id = $contributionResult['id'] ?? NULL;
     // if our template contribution has a membership payment, make this one also
     if ($domemberships && !empty($contribution_template['contribution_id'])) {
       try {


### PR DESCRIPTION
Replaces deprecated function with equivalent null-coalescing operator. Behavior should be the same before/after.