### PR TITLE
Replace reference to deprecated exception class

### DIFF
--- a/CRM/Contributionrecur/MembershipImplicit.php
+++ b/CRM/Contributionrecur/MembershipImplicit.php
@@ -95,7 +95,7 @@ function contributionrecur_membershipImplicit($contact, $contributions, $options
             // unset($applied_contributions[$i]);
             $return[] = 'Converted contribution '. $contribution['id'] .' of contact id '. $contact_id .' to financial type id '. $membership_financial_type_id;
           }
-          catch (CiviCRM_API3_Exception $e) {
+          catch (CRM_Core_Exception $e) {
             $return[] = $e->getMessage();
             $return[] = $p;
           }
@@ -132,7 +132,7 @@ function contributionrecur_membershipImplicit($contact, $contributions, $options
           civicrm_api3('MembershipPayment','create', array('contribution_id' => $reversal_contribution['id'], 'membership_id' => $membership['id']));
           $return[] = 'Created membership and reversal contributions for contact id '. $contact_id;
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $return[] = $e->getMessage();
           $return[] = $p;
         }
@@ -140,7 +140,7 @@ function contributionrecur_membershipImplicit($contact, $contributions, $options
     }
     $return[] = 'Updated membership '.$membership['id'];
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     if ($create_new_membership_type_id) {
       $contribution = array_shift($contributions);
       $new_membership = array('contact_id' => $contact_id, 'membership_type_id' => $create_new_membership_type_id, 'join_date' => $contribution['receive_date']);
@@ -150,7 +150,7 @@ function contributionrecur_membershipImplicit($contact, $contributions, $options
         civicrm_api3('MembershipPayment','create', array('contribution_id' => $contribution['id'], 'membership_id' => $membership['id']));
         $return[] = 'Created membership '.$membership['id'];
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
         $return[] = 'Error creating new membership';
         $return[] = $e->getMessage();
         $return[] = $new_membership;

--- a/CRM/Contributionrecur/Task/CompletePending.php
+++ b/CRM/Contributionrecur/Task/CompletePending.php
@@ -130,7 +130,7 @@ WHERE  id IN ( $contribIDs )";
         $contributionResult = civicrm_api3('contribution', 'create', $row);
       }
       catch (Exception $e) {
-        throw new API_Exception('Failed to complete transaction: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+        throw new CRM_Core_Exception('Failed to complete transaction: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
       }
 
     }

--- a/CRM/Contributionrecur/Task/MembershipPayments.php
+++ b/CRM/Contributionrecur/Task/MembershipPayments.php
@@ -116,7 +116,7 @@ AND    {$this->_componentClause}";
       try {
         $membership = civicrm_api3('Membership', 'getsingle', array('sequential' => 1, 'contact_id' => $contact_id, 'membership_type_id' => $values['membership_type_id']));
       }
-      catch (CiviCRM_API3_Exception $e) {
+      catch (CRM_Core_Exception $e) {
        // ignore
       }
       if (empty($membership['id'])) {
@@ -155,13 +155,13 @@ AND    {$this->_componentClause}";
           civicrm_api3('MembershipPayment','create', array('contribution_id' => $reversal_contribution['id'], 'membership_id' => $membership['id']));
           $return[] = 'Created reversal contributions for contact id '. $contact_id;
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           $return[] = $e->getMessage();
           $return[] = $p;
         }
       }
       catch (Exception $e) {
-        throw new API_Exception('Error generating contributions: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
+        throw new CRM_Core_Exception('Error generating contributions: ' . $e->getMessage() . "\n" . $e->getTraceAsString());
       }
     }
     CRM_Core_Session::setStatus(ts('Contributions have been generated for selected contact(s).'), ts('Contributions generated'), 'success');

--- a/api/v3/Job/Membershipimplicit.php
+++ b/api/v3/Job/Membershipimplicit.php
@@ -55,7 +55,7 @@ function _civicrm_api3_job_membershipimplicit_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_membershipimplicit($params = array()) {
   if (empty($params['mapping'])) return;

--- a/api/v3/Job/Recurringgenerate.php
+++ b/api/v3/Job/Recurringgenerate.php
@@ -44,7 +44,7 @@ function _civicrm_api3_job_recurringgenerate_spec(&$spec) {
  * @return array API result descriptor
  * @see civicrm_api3_create_success
  * @see civicrm_api3_create_error
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function civicrm_api3_job_recurringgenerate($params) {
   // TODO: what kind of extra security do we want or need here to prevent it from being triggered inappropriately? Or does it matter?
@@ -257,7 +257,7 @@ function civicrm_api3_job_recurringgenerate($params) {
         try {
           $result = civicrm_api3('ContributionSoft', 'create', $params);
         }
-        catch (CiviCRM_API3_Exception $e) {
+        catch (CRM_Core_Exception $e) {
           CRM_Core_Error::debug_var('Unexpected Exception', $e);
           // just log the error and continue
         }

--- a/contributionrecur.php
+++ b/contributionrecur.php
@@ -288,7 +288,7 @@ function _contributionrecur_payment_processor_id($contribution_recur_id) {
       $result = FALSE;
     }
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     \Civi::log()->error("_contributionrecur_payment_processor_id: contribution_recur_id: $contribution_recur_id, Exception: $e");
     $result = FALSE;
   }
@@ -318,7 +318,7 @@ function _contributionrecur_pp_info($payment_processor_id, $return, $class_name 
       $result = FALSE;
     }
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     \Civi::log()->error("_contributionrecur_pp_info: payment_processor_id: $payment_processor_id, Exception: $e");
     $result = FALSE;
   }
@@ -489,13 +489,13 @@ function contributionrecur_CRM_Contribute_Form_UpdateSubscription(&$form) {
   try {
     $recur = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $crid));
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     return;
   }
   try {
     $contact = civicrm_api3('Contact', 'getsingle', array('id' => $recur['contact_id']));
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     return;
   }
   // turn off default notification checkbox, most will want to hide it as well.
@@ -564,7 +564,7 @@ function contributionrecur_pageRun_CRM_Contribute_Page_ContributionRecur($page) 
   try {
     $recur = civicrm_api3('ContributionRecur', 'getsingle', array('id' => $crid));
   }
-  catch (CiviCRM_API3_Exception $e) {
+  catch (CRM_Core_Exception $e) {
     return;
   }
   // add the 'generate ad hoc contribution form' link


### PR DESCRIPTION
The api-specific exception classes have been deprecated and will soon be removed from core.
They are identical to CRM_Core_Exception.